### PR TITLE
Switch asset_path to asset tag

### DIFF
--- a/template/_includes/head.html
+++ b/template/_includes/head.html
@@ -10,15 +10,15 @@
   <meta property="og:url" content="{{ page.url | absolute_url }}">
   <meta property="og:description" content="{{ page.description }}">
   <meta property="og:site_name" content="{{ site.name }}">
-  <meta property="og:image" content="{{ site.url }}{% asset_path og-image.jpg %}">
+  <meta property="og:image" content="{{ site.url }}{% asset og-image.jpg @path %}">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:url" content="{{ page.url | absolute_url }}">
   <meta name="twitter:title" content="{{ page.title }}">
   <meta name="twitter:description" content="{{ page.description }}">
-  <meta name="twitter:image" content="{{ site.url }}{% asset_path og-image.jpg %}">
+  <meta name="twitter:image" content="{{ site.url }}{% asset og-image.jpg @path %}">
 
-  <link rel="apple-touch-icon" href="{% asset_path apple-touch-icon.png %}">
+  <link rel="apple-touch-icon" href="{% asset apple-touch-icon.png @path %}">
+  {% asset application.scss %}
 
-  {% stylesheet application %}
 </head>

--- a/template/_includes/javascripts.html
+++ b/template/_includes/javascripts.html
@@ -1,10 +1,10 @@
-{% javascript vendor %}
-{% javascript application %}
+{% asset vendor.js %}
+{% asset application.js %}
 
 {% if site.ga_analytics %}
   <script>
-    window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
-    ga('create','{{ site.ga_analytics }}','auto');ga('send','pageview')
+      window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
+      ga('create','{{ site.ga_analytics }}','auto');ga('send','pageview')
   </script>
   <script src="https://www.google-analytics.com/analytics.js" async defer></script>
 {% endif %}


### PR DESCRIPTION
{% asset_path %} tag is not supported in the newest version of jekyll-assets library so it doesn't work anymore. Also stylesheet and javascript tags are removed. 
https://github.com/envygeeks/jekyll-assets#tag--asset--img