### PR TITLE
Upgrade build-time packages for dependabot 

### DIFF
--- a/kickster.gemspec
+++ b/kickster.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency("thor", "~> 0")
-  spec.add_development_dependency "bundler", "~> 1.8"
+  spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake", ">= 12.3.3"
 end

--- a/kickster.gemspec
+++ b/kickster.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency("thor", "~> 0")
   spec.add_development_dependency "bundler", "~> 1.8"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
 end

--- a/kickster.gemspec
+++ b/kickster.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency("thor", "~> 0")
-  spec.add_development_dependency "bundler", ">= 2.2.10"
-  spec.add_development_dependency "rake", ">= 12.3.3"
+  spec.add_development_dependency "bundler", "~> 2.2", ">= 2.2.10"
+  spec.add_development_dependency "rake", "~> 12.3", ">= 12.3.3"
 end


### PR DESCRIPTION
GitHub's Dependabot is unhappy with `kickster.gemspec`. Force some upgrades.

Dependabot suggested the particular version pinning. I'm not a Ruby person, so feel free to change it.